### PR TITLE
Update NewGame.gd

### DIFF
--- a/src/fragment_forge/NewGame.gd
+++ b/src/fragment_forge/NewGame.gd
@@ -33,8 +33,11 @@ func _on_DeckLoader_deck_loaded(deck) -> void:
 	deck_title.text = deck.name
 	deck_details.visible = true
 	deck_details.text = str(deck.total) + " Cards"
-	start_button.disabled = false
-
+	if (deck.total >= 30):
+		start_button.disabled = false
+	else:
+		start_button.disabled = true
+		
 func _on_Decrease_pressed() -> void:
 	if ffc.difficulty > ffc.Difficulties.START + 1:
 		ffc.difficulty -= 1


### PR DESCRIPTION
Starting a game using a deck with fewer than 5 cards causes a crash. 
Decks are supposed to have 30 cards.
Although you can SAVE a deck with fewer cards (as a draft), you shouldn't be able to start a game with a deck like that.